### PR TITLE
Upgrading deployment chart to apps/v1

### DIFF
--- a/install/helm/sqoop/templates/1-sqoop-deployment.yaml
+++ b/install/helm/sqoop/templates/1-sqoop-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sqoop


### PR DESCRIPTION
To enable 1.16+ K8S compatibility, moving apiVersion to apps/v1.

Related to: https://github.com/solo-io/sqoop/issues/44