### PR TITLE
Update golang.org/x/xerrors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1417,15 +1417,14 @@
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c44a77760372a998be8d4656e8d3c865f68735ec4cad1743a245903a58f64249"
+  digest = "1:918a46e4a2fb83df33f668f5a6bd51b2996775d073fce1800d3ec01b0a5ddd2b"
   name = "golang.org/x/xerrors"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "3ee3066db522c6628d440a3a91c4abdd7f5ef22f"
+  revision = "9bdfabe68543c54f90421aeb9a60ef8061b5b544"
 
 [[projects]]
   digest = "1:d2a8db567a76203e3b41c1f632d86485ffd57f8e650a0d1b19d240671c2fddd7"
@@ -2196,7 +2195,6 @@
     "github.com/solo-io/solo-kit/pkg/code-generator/cmd",
     "github.com/solo-io/solo-kit/pkg/code-generator/docgen/options",
     "github.com/solo-io/solo-kit/pkg/errors",
-    "github.com/solo-io/solo-kit/pkg/utils/kubeutils",
     "github.com/solo-io/solo-kit/test/helpers",
     "github.com/solo-io/solo-kit/test/tests/typed",
     "github.com/spf13/cobra",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,3 +67,7 @@
 [[override]]
   name = "github.com/solo-io/go-utils"
   version = "0.8.16"
+
+[[override]]
+  name = "golang.org/x/xerrors"
+  revision = "9bdfabe68543c54f90421aeb9a60ef8061b5b544"


### PR DESCRIPTION
Updating golang.org/x/xerrors dependency to last version, works with go1.13.8 