### PR TITLE
Add go.mod to solve compilation problems in certain scenarios

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,50 @@
+module github.com/solo-io/sqoop
+
+
+replace github.com/vektah/gqlgen => github.com/99designs/gqlgen v0.0.0-20180621101208-d26ef2a2622e
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
+
+replace k8s.io/apiserver => k8s.io/apiserver v0.0.0-20181204001702-9caa0299108f
+
+replace k8s.io/api => k8s.io/api v0.0.0-20181204000039-89a74a8d264d
+
+replace k8s.io/client-go => k8s.io/client-go v10.0.0+incompatible
+
+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20181204003920-20c909e7c8c3
+
+replace k8s.io/kubernetes => k8s.io/kubernetes v1.13.0
+
+replace k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93
+
+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.0.0-20181204004549-a04da5c88c07
+
+replace github.com/solo-io/go-checkpoint => github.com/solo-io/go-checkpoint v0.0.0-20181217204546-b798a7563f83
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.6.9
+
+require (
+	github.com/99designs/gqlgen v0.11.3 // indirect
+	github.com/Azure/go-autorest/autorest v0.10.2 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.8.3 // indirect
+	github.com/envoyproxy/go-control-plane v0.9.5 // indirect
+	github.com/gogo/googleapis v1.4.0 // indirect
+	github.com/gogo/protobuf v1.3.1
+	github.com/gophercloud/gophercloud v0.11.0 // indirect
+	github.com/gorilla/mux v1.7.4
+	github.com/hashicorp/consul/api v1.4.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0
+	github.com/hashicorp/vault/api v1.0.4 // indirect
+	github.com/lyft/protoc-gen-validate v0.3.0 // indirect
+	github.com/pkg/errors v0.8.1
+	github.com/radovskyb/watcher v1.0.7 // indirect
+	github.com/solo-io/gloo v0.13.25
+	github.com/solo-io/go-checkpoint v0.0.0-20190731194117-b56cd9c812e8
+	github.com/solo-io/go-utils v0.8.16
+	github.com/solo-io/solo-kit v0.9.6
+	github.com/vektah/gqlgen v0.0.0-00010101000000-000000000000
+	go.opencensus.io v0.18.0
+	go.uber.org/zap v1.9.1
+	k8s.io/apimachinery v0.0.0-20190104073114-849b284f3b75+incompatible
+	k8s.io/client-go v10.0.0+incompatible
+)


### PR DESCRIPTION
Golang package management is a historical problem, and the current go mod solves this problem very well, is the de facto standard。 

In my environment (golang 1.14), compiling sqoop reports an error （#50）. My colleague converted gopkg.toml to go.mod, which solved the compilation problem very well. This may be encountered by others.  